### PR TITLE
Make animation and console panel buttons toggle visibility.

### DIFF
--- a/src/components/LayerList.jsx
+++ b/src/components/LayerList.jsx
@@ -85,7 +85,7 @@ const Layer = ({ layer, element, isSelected, dispatch }) => {
 };
 
 const LayerList = () => {
-    const [[elements, layers, selectedLayerIds], dispatch] = useOverlayEditorContext(state => state.elements, state => state.overlay.layers, state => state.selectedLayerIds);
+    const [[elements, layers, selectedLayerIds, editors], dispatch] = useOverlayEditorContext(state => state.elements, state => state.overlay.layers, state => state.selectedLayerIds, state => state.editors);
 
     const onCreateLayer = useCallback(elementName => {
         console.log({ createlayer: elementName });
@@ -99,7 +99,7 @@ const LayerList = () => {
    return (
     <div className="main-list layer-list">
         <div className="actions">
-            <Button text="Animation" small={true} minimal={true} icon="walk" onClick={() => dispatch("OpenEditor", { type: "animation" })} />
+            <Button text="Animation" small={true} minimal={true} icon="walk" active={editors.some(panel => panel.key === "animation")} onClick={() => dispatch("ToggleEditor", { type: "animation" })} />
             <div className="right">
                 <Popover position="right-top">
                     <Button small={true} title="New Layer" icon="plus" intent="primary" rightIcon="caret-right" />

--- a/src/shared/OverlayEditorContext.js
+++ b/src/shared/OverlayEditorContext.js
@@ -272,7 +272,33 @@ const Reducers = {
             return { layerDomElements: ps.layerDomElements.filter(r => r.id != id) };
         else
             return { layerDomElements: [...ps.layerDomElements, { id, domElement }] };
-    },    
+    },
+    ToggleEditor: (ps, { type, params }) => {
+        let newState = {};
+        const editorType = Editors[type];
+        const key = editorType.key(params);
+
+        const index = ps.editors.findIndex(r => r.key == key);
+        if (index == -1) {
+            newState.editors = [...ps.editors, {key, type, params}];
+            newState.selectedEditorTab = key;
+        }
+        else {
+            newState.editors = [...ps.editors]
+            newState.editors.splice(index, 1);
+
+            if (ps.selectedEditorTab == key) {
+                if (newState.editors.length > index)
+                    ps.selectedEditorTab = newState.editors[index].key;
+                else if (index > 0)
+                    ps.selectedEditorTab = newState.editors[index - 1].key;
+                else
+                    ps.selectedEditorTab = null;
+            }
+        }
+
+        return newState;
+    },
     OpenEditor: (ps, { type, params }) => {
         let newState = {};
         const editorType = Editors[type];


### PR DESCRIPTION
Instead of the Animation and Console action buttons doing nothing if the panel is already option, this would close the panel. I think this is behavior people expect from apps with expandable panes.