### PR TITLE
Layer deselection hotkey + bugfix

### DIFF
--- a/src/shared/OverlayEditorContext.js
+++ b/src/shared/OverlayEditorContext.js
@@ -723,7 +723,7 @@ const Reducers = {
         // no need to sort since we add these in indexed order
 
         // find the top-most index
-        const topMostIndex = indexedLayers.map(layer => layer.index).reduce((max, curr) => Math.min(max, curr), 10000);
+        let topMostIndex = indexedLayers.map(layer => layer.index).reduce((max, curr) => Math.min(max, curr), 10000);
 
         // if any layer is already at the top, immediately return and do nothing
         if (topMostIndex == 0) { return; }
@@ -752,7 +752,7 @@ const Reducers = {
         });
 
         // find the bottom-most index
-        const bottomMostIndex = indexedLayers.map(layer => layer.index).reduce((max, curr) => Math.max(max, curr), 0);
+        let bottomMostIndex = indexedLayers.map(layer => layer.index).reduce((max, curr) => Math.max(max, curr), 0);
 
         // if any layer is already at the bottom, immediately return and do nothing
         if (bottomMostIndex == ps.overlay.layers.length - 1) { return; }

--- a/src/shared/useHotkeys.js
+++ b/src/shared/useHotkeys.js
@@ -19,6 +19,7 @@ const HotkeySets = {
         { key: "Tab", shift: true, action: (dispatch) => dispatch("SelectNextLayer", true) },
         { key: "Delete", action: (dispatch) => dispatch("DeleteSelection") },
         { key: "c", ctrl: true, action: (dispatch) => dispatch("CopySelectedLayersToClipboard") },
+        { key: "Escape", action: (dispatch) => dispatch("SelectLayers", [])}
     ],
     MOVE_AND_RESIZE: [
         { key: "c", ctrl: false, action: (dispatch, context) => dispatch("CenterSelectedLayers", context.current) },


### PR DESCRIPTION
- Escape deselects all layers
- Fixed Ctrl+] and Ctrl+[ not raising and lowering completely.